### PR TITLE
Update dependencies; refactor for nalgebra 0.29 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 Cargo.lock
 result.jpg
+.DS_Store
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,22 +21,22 @@ name = "pico_detect"
 bench = false
 
 [dependencies]
-derive-new = "0.5"
-nalgebra = "^0.21"
-image = { version = "^0.23", default-features = false }
-imageproc = { version = "^0.21", default-features = false }
-rand = "^0.7"
+derive-new = "0.5.9"
+nalgebra = "0.29.0"
+image = { version = "0.23.14", default-features = false }
+imageproc = { version = "0.22.0", default-features = false }
+rand = "0.8.4"
 
 [dev-dependencies]
-image = "^0.23"
-imageproc = "^0.21"
-criterion = "0.3.3"
-structopt = "0.3"
-approx = "0.4.0"
-rand_xorshift = "0.2.0"
+image = "0.23.14"
+imageproc = "0.22.0"
+criterion = "0.3.5"
+structopt = "0.3.23"
+approx = "0.5.0"
+rand_xorshift = "0.3.0"
 
 [dev-dependencies.cargo-husky]
-version = "1"
+version = "1.5.0"
 features = ["precommit-hook", "run-cargo-clippy"]
 
 [[bench]]

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -42,7 +42,7 @@ struct Face {
 fn main() {
     let opt = Opt::from_args();
     let dyn_image = image::open(&opt.input).expect("Cannot open input image.");
-    let (gray, mut image) = (dyn_image.to_luma(), dyn_image.to_rgb());
+    let (gray, mut image) = (dyn_image.to_luma8(), dyn_image.to_rgb8());
 
     let (facefinder, mut shaper, puploc) = load_models();
 

--- a/src/detection.rs
+++ b/src/detection.rs
@@ -74,7 +74,7 @@ impl Detection {
             let mut score = det1.score();
             let mut count = 1usize;
             for (det2, j) in detections[(i + 1)..].iter().zip((i + 1)..) {
-                if det1.iou(&det2) > threshold {
+                if det1.iou(det2) > threshold {
                     assignments[j] = true;
                     tvec += det2.center().coords;
                     score += det2.score();

--- a/src/localizer.rs
+++ b/src/localizer.rs
@@ -91,12 +91,15 @@ impl Localizer {
 
         // println!("\ninit: {}", initial_roi);
         for _ in 0..nperturbs {
-            let mut roi = initial_roi.clone();
+            let mut roi = initial_roi;
+
             roi.prepend_scaling_mut(rng.sample(self.distrs.0));
+
             roi.isometry.translation.vector.x = scaling.mul_add(
                 rng.sample(self.distrs.1),
                 initial_roi.isometry.translation.vector.x,
             );
+
             roi.isometry.translation.vector.y = scaling.mul_add(
                 rng.sample(self.distrs.1),
                 initial_roi.isometry.translation.vector.y,

--- a/src/shaper.rs
+++ b/src/shaper.rs
@@ -2,14 +2,14 @@ use std::io::{Error, ErrorKind, Read};
 
 use image::{GenericImageView, Luma};
 use imageproc::rect::Rect;
-use nalgebra::{Affine2, Dynamic, MatrixMN, Point2, Vector2, U2};
+use nalgebra::{Affine2, Dynamic, OMatrix, Point2, Vector2, U2};
 
 use super::bintest::FeatureBintest;
 use super::geometry::{find_affine, find_similarity};
 use super::node::ThresholdNode;
 use super::utils::get_pixel_with_fallback;
 
-pub type ShapeMatrix = MatrixMN<f32, U2, Dynamic>;
+pub type ShapeMatrix = OMatrix<f32, U2, Dynamic>;
 
 struct Tree {
     nodes: Vec<ThresholdNode>,
@@ -37,7 +37,11 @@ impl Forest {
         debug_assert_eq!(self.deltas.len(), self.anchors.len());
         debug_assert_eq!(features.len(), self.anchors.len());
 
-        let transform_to_shape = find_similarity(&initial_shape, &shape);
+        let transform_to_shape =
+            find_similarity(
+                initial_shape,
+                shape,
+            );
 
         for ((delta, anchor), feature) in self
             .deltas

--- a/tests/validation.rs
+++ b/tests/validation.rs
@@ -136,5 +136,5 @@ fn validate_pupil_localization() {
 pub fn load_test_image() -> GrayImage {
     image::open("./tests/assets/Lenna_(test_image).png")
         .unwrap()
-        .to_luma()
+        .to_luma8()
 }


### PR DESCRIPTION
Hey,

this updates nalgebra (and all other dependencies) to the latest releases.

This required slight refactoring (i.e. *point.to_homogeneous().data is not a slice anymore but a container that exposes as_slice and as_mut_slice).

Additionally, since you last released pico-detect, many new suggestions have been added to clippy. This addresses most of the issues it raised.

Most importantly, this refactors the MaybeUninit calls to construct an array of MaybeUninit<T> first before later overwriting the respective fields and finally transmuting the [MaybeUninit<T>; ..] to [T; ..].

Thanks for this library!